### PR TITLE
Remove redundant package from preview install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Now the *Font Name* given here is the one you should use in the theme.txt file
 **◻️ First, install the prerequisites :**
 ```bash
 # for Debian / Ubuntu
-sudo apt install grub-common ovmf xorriso qemu qemu-system mtools python3 python3-pip
+sudo apt install grub-common ovmf xorriso qemu-system mtools python3 python3-pip
 
 # for Arch
 sudo pacman -S grub-common ovmf xorriso qemu-full mtools python python-pip


### PR DESCRIPTION
Qemu doesn't seem to be available standalone, so the command fails. It's already a part of qemu-system, so it's not necessary to include qemu itself anyway.

This is just the result I got when I tried to install on Debian though, might want to check with Ubuntu just in case.